### PR TITLE
Fix effect orders

### DIFF
--- a/src/constants/cardList.ts
+++ b/src/constants/cardList.ts
@@ -1421,8 +1421,9 @@ export const cardList: Readonly<Record<number, Card>> = {
 		},
 		modificationOptions(hand) {
 			const selfIndex = hand.findIndex(card => card.id === this.id)
-			const usedVillainCount = count(hand, (card, index) => card.type === CARD_TYPE.VILLAIN && index < selfIndex)
-			if (usedVillainCount) {
+			// Block villain effects from happening before Squirrel Girl blanks their text.
+			// Only allow Selene to go before Squirrel Girl since it's up to the player which one blanks the other
+			if (hand.some((card, index) => index < selfIndex && card.type === CARD_TYPE.VILLAIN && card.id !== 76)) {
 				throw new Error('Trying to blank the text of a used card')
 			}
 			return 1

--- a/src/constants/cardList.ts
+++ b/src/constants/cardList.ts
@@ -1,12 +1,11 @@
 import i18n from 'i18next'
-import type { Dictionary } from 'lodash'
 import sumBy from 'lodash/sumBy'
 import { Card, CARD_TYPE, ModifiedCard, TAG } from '../types/card.ts'
 import { findCard, removeTag } from '../utils/card.ts'
 import { generateCombinations } from '../utils/randomization.ts'
 import { count } from '../utils/whyIsThisNotInLodash.ts'
 
-export const cardList: Readonly<Dictionary<Card>> = {
+export const cardList: Readonly<Record<number, Card>> = {
 	//#region Ally
 	1: {
 		// Forge
@@ -217,6 +216,10 @@ export const cardList: Readonly<Dictionary<Card>> = {
 			}
 		},
 		modificationOptions(hand) {
+			const selfIndex = hand.findIndex(card => card.id === this.id)
+			if (hand.some((card, index) => card.id === 33 && index > selfIndex)) {
+				throw new Error('X-Jet must be evaluated after Vision')
+			}
 			return count(
 				hand,
 				card => !card.isBlanked && (card.type === CARD_TYPE.HERO || card.type === CARD_TYPE.ALLY)
@@ -1254,6 +1257,9 @@ export const cardList: Readonly<Dictionary<Card>> = {
 		},
 		modificationOptions(hand) {
 			const selfIndex = hand.findIndex(card => card.id === this.id)
+			if (hand.some((card, index) => card.id === 61 && index < selfIndex)) {
+				throw new Error('Using Magneto after Hack In')
+			}
 			if (hand.some((card, index) => card.type === CARD_TYPE.EQUIPMENT && index < selfIndex)) {
 				throw new Error('Trying to blank a used card')
 			}

--- a/src/constants/cardList.ts
+++ b/src/constants/cardList.ts
@@ -427,30 +427,29 @@ export const cardList: Readonly<Record<number, Card>> = {
 		tags: [TAG.TECH, TAG.WAKANDA],
 		effect(hand, index) {
 			const tagOptions = [TAG.AGILITY, TAG.RANGE, TAG.STRENGTH]
-			const ownTagSelectionIndex = index % 3
-			const ownTagChoice = tagOptions[ownTagSelectionIndex]
-			const targetCardSelectionIndex = Math.floor(index / 3)
-			let indexCount = targetCardSelectionIndex
-			const targetCard = hand.find(card => {
-				if (card.id !== this.id && (card.type === CARD_TYPE.HERO || card.type === CARD_TYPE.ALLY)) {
-					if (indexCount < 3) {
-						return true
-					}
-					indexCount -= card.modifiedTags.length
-				}
-			}) as ModifiedCard
-			const targetCardTagChoice = tagOptions[indexCount]
-			const self = findCard(hand, 28)
+			const ownTagChoice = tagOptions[index % 3]
+
+			const self = findCard(hand, this.id)
 			self.modifiedTags.push(ownTagChoice)
-			targetCard.modifiedTags.push(targetCardTagChoice)
+
+			const targetCards = hand.filter(
+				card => (card.id !== this.id && card.type === CARD_TYPE.HERO) || card.type === CARD_TYPE.ALLY
+			)
+			if (targetCards.length === 0) return
+
+			const targetCardSelectionIndex = Math.floor(index / 9)
+			const targetCardTagChoice = Math.floor((index % 9) / 3)
+			const targetCard = targetCards[targetCardSelectionIndex]
+			targetCard.modifiedTags.push(tagOptions[targetCardTagChoice])
 		},
 		modificationOptions(hand) {
 			const targetCardCount = count(
 				hand,
 				card => card.id !== this.id && (card.type === CARD_TYPE.HERO || card.type === CARD_TYPE.ALLY)
 			)
-			// Affects self plus one other card
-			return (targetCardCount + 1) * 3
+			// 3 options if Shuri is the only hero/ally.
+			// Otherwise, 3 options for Shuri times 3 for the target card times the number of target cards
+			return targetCardCount === 0 ? 3 : targetCardCount * 9
 		},
 		score() {
 			return this.power

--- a/src/utils/score.test.ts
+++ b/src/utils/score.test.ts
@@ -280,6 +280,26 @@ describe('scoreHand', () => {
 					cardList[18]
 				],
 				score: 77
+			},
+			{
+				id: 11,
+				hand: [
+					// Squirrel Girl
+					cardList[80],
+					// Hulk Operations
+					cardList[7],
+					// Angel
+					cardList[34],
+					// Kang
+					cardList[62],
+					// Selene
+					cardList[76],
+					// Sauron
+					cardList[64],
+					// Hawkeye
+					cardList[39]
+				],
+				score: 80
 			}
 		]
 		//#endregion example hands

--- a/src/utils/score.test.ts
+++ b/src/utils/score.test.ts
@@ -240,6 +240,46 @@ describe('scoreHand', () => {
 					cardList[62]
 				],
 				score: 94
+			},
+			{
+				id: 9,
+				hand: [
+					// Avoid Crossfire
+					cardList[60],
+					// Shuri
+					cardList[28],
+					// Jean Grey
+					cardList[32],
+					// X-Jet
+					cardList[15],
+					// Spider-Man
+					cardList[22],
+					// Angel
+					cardList[34],
+					// Selene
+					cardList[76]
+				],
+				score: 89
+			},
+			{
+				id: 10,
+				hand: [
+					// Avoid Crossfire
+					cardList[60],
+					// Shuri
+					cardList[28],
+					// Jean Grey
+					cardList[32],
+					// Sauron
+					cardList[64],
+					// Angel
+					cardList[34],
+					// Find Higher Ground
+					cardList[55],
+					// Cerebro
+					cardList[18]
+				],
+				score: 77
 			}
 		]
 		//#endregion example hands

--- a/src/utils/score.test.ts
+++ b/src/utils/score.test.ts
@@ -177,7 +177,47 @@ describe('scoreHand', () => {
 					// Heimdall
 					cardList[2]
 				],
-				score: 33
+				score: 13
+			},
+			{
+				id: 7,
+				hand: [
+					// Magneto
+					cardList[74],
+					// Hack In
+					cardList[61],
+					// Discover Weakness
+					cardList[56],
+					// Dora Milaja
+					cardList[6],
+					// Hulk Operations
+					cardList[7],
+					// Angel
+					cardList[34],
+					// Beast
+					cardList[35]
+				],
+				score: 61
+			},
+			{
+				id: 8,
+				hand: [
+					// X-Jet
+					cardList[15],
+					// Vision
+					cardList[33],
+					// Find Higher Ground
+					cardList[55],
+					// Angel
+					cardList[34],
+					// Hawkeye
+					cardList[39],
+					// Jean Grey
+					cardList[32],
+					// Kang
+					cardList[62]
+				],
+				score: 94
 			}
 		]
 		//#endregion example hands

--- a/src/utils/score.test.ts
+++ b/src/utils/score.test.ts
@@ -32,6 +32,28 @@ describe('scoreHand', () => {
 		]
 		const result = scoreHand(hand)
 		expect(result.score).toBeUndefined()
+		expect(result.finalHand.length).toBe(7)
+	})
+	it('returns undefined score and a card list when hand is invalid from blanked cards', () => {
+		const hand: Card[] = [
+			// X-Jet
+			cardList[15],
+			// Vision
+			cardList[33],
+			// Find Higher Ground
+			cardList[55],
+			// Mystique (becomes blanked)
+			cardList[66],
+			// Avoid Crossfire
+			cardList[60],
+			// Hidden Lair
+			cardList[52],
+			// Vibranium Shield
+			cardList[16]
+		]
+		const result = scoreHand(hand)
+		expect(result.score).toBeUndefined()
+		expect(result.finalHand.length).toBe(7)
 	})
 	it('subtracts points for Loki draw', () => {
 		const hand: Card[] = [

--- a/src/utils/score.ts
+++ b/src/utils/score.ts
@@ -68,7 +68,7 @@ export const scoreHand = (hand: Card[], lokiPenalty?: number): ScoreResult => {
 	}
 
 	return {
-		score: maxScore === undefined ? undefined : maxScore - (lokiPenalty || 0),
+		score: maxScore,
 		message: 'Success',
 		finalHand: optimalHand
 	}

--- a/src/utils/score.ts
+++ b/src/utils/score.ts
@@ -110,7 +110,7 @@ const applyEffectsRecursive = (hand: ModifiedCard[], index: number, lokiPenalty:
 
 	const currentCard = hand[index]
 	if (!currentCard.isBlanked && !currentCard.isTextBlanked && currentCard.modificationOptions && currentCard.effect) {
-		const optionCount = currentCard.modificationOptions(hand)
+		const optionCount = currentCard.modificationOptions(hand.filter(card => !card.isBlanked))
 		if (!optionCount) {
 			return applyEffectsRecursive(hand, index + 1, lokiPenalty)
 		}

--- a/src/utils/score.ts
+++ b/src/utils/score.ts
@@ -58,7 +58,9 @@ export const scoreHand = (hand: Card[], lokiPenalty?: number): ScoreResult => {
 		const modifiedHand = cloneDeep(orderedHand)
 		try {
 			const { score, hand: resultHand } = applyEffectsRecursive(modifiedHand, 0, lokiPenalty)
-			if (score !== undefined && (maxScore === undefined || score > maxScore)) {
+			// Save cards as optimal hand for the first result so we can guarantee having updated cards
+			// Otherwise only update the hand when we successfully get a score and it's higher than the previous one
+			if (optimalHand.length === 0 || (score !== undefined && (maxScore === undefined || score > maxScore))) {
 				maxScore = score
 				optimalHand = resultHand
 			}


### PR DESCRIPTION
closes #5, #6

Several fixes regarding card effect ordering rules and some option counts related to open issues as well as others.

Squirrel Girl - allow Selene to go first which can blank Squirrel Girl.
Magneto - must go before Hack In to prevent it from adding extra intel tags on removed tech tags
X-Jet - must go after Vision to ensure Vision doesn't add a second Flight tag to himself
Shuri - Fixed logic for the number of options to select as well as the logic for which tags to add for each option

Scoring function filters out blanked cards before calling modificationOptions
Scoring function was subtracting Loki's selected card as well as reducing Loki's power, doubling the penalty
Scoring function could return a blank finalHand after scoring if it became invalid (such as blanking all villains)

